### PR TITLE
Do not allow players to ShiftClick items to output slot

### DIFF
--- a/src/main/java/cazador/furnaceoverhaul/inventory/ContainerFO.java
+++ b/src/main/java/cazador/furnaceoverhaul/inventory/ContainerFO.java
@@ -17,6 +17,7 @@ public class ContainerFO extends Container {
 
 	public static final int SLOTS_TE = 0;
 	public static final int SLOTS_TE_SIZE = 6;
+	public static final int SLOTS_TE_INPUT_SIZE = 5;
 	public static final int SLOTS_INVENTORY = SLOTS_TE_SIZE;
 	public static final int SLOTS_HOTBAR = SLOTS_INVENTORY + 3 * 9;
 
@@ -27,10 +28,10 @@ public class ContainerFO extends Container {
 		this.te = te;
 		this.addSlotToContainer(new SlotFurnaceInput(te.getInventory(), 0, 56, 17));
 		this.addSlotToContainer(new SlotFurnaceFuel(te.getInventory(), 1, 56, 53));
-		this.addSlotToContainer(new SlotFurnaceOutput(playerInv.player, te.getInventory(), 2, 116, 35));
-		this.addSlotToContainer(new SlotUpgrade(te.getInventory(), 3, 12, 13));
-		this.addSlotToContainer(new SlotUpgrade(te.getInventory(), 4, 12, 34));
-		this.addSlotToContainer(new SlotUpgrade(te.getInventory(), 5, 12, 55));
+		this.addSlotToContainer(new SlotUpgrade(te.getInventory(), 2, 12, 13));
+		this.addSlotToContainer(new SlotUpgrade(te.getInventory(), 3, 12, 34));
+		this.addSlotToContainer(new SlotUpgrade(te.getInventory(), 4, 12, 55));
+		this.addSlotToContainer(new SlotFurnaceOutput(playerInv.player, te.getInventory(), 5, 116, 35));
 
 		for (int i = 0; i < 3; ++i) {
 			for (int j = 0; j < 9; ++j) {
@@ -74,9 +75,9 @@ public class ContainerFO extends Container {
 					int s = TileEntityIronFurnace.SLOT_FUEL;
 					if (!mergeItemStack(stack, s, s + 1, false)) { return ItemStack.EMPTY; }
 				}
-				if (!mergeItemStack(stack, SLOTS_TE, SLOTS_TE + SLOTS_TE_SIZE, false)) { return ItemStack.EMPTY; }
+				if (!mergeItemStack(stack, SLOTS_TE, SLOTS_TE + SLOTS_TE_INPUT_SIZE, false)) { return ItemStack.EMPTY; }
 			} else if (index >= SLOTS_HOTBAR && index < SLOTS_HOTBAR + 9) {
-				if (!mergeItemStack(stack, SLOTS_INVENTORY, SLOTS_INVENTORY + 3 * 9, false)) { return ItemStack.EMPTY; }
+				if (!mergeItemStack(stack, SLOTS_INVENTORY, SLOTS_HOTBAR, false)) { return ItemStack.EMPTY; }
 			} else if (!mergeItemStack(stack, SLOTS_INVENTORY, SLOTS_HOTBAR + 9, true)) { return ItemStack.EMPTY; }
 
 			slot.onSlotChanged();

--- a/src/main/java/cazador/furnaceoverhaul/tile/TileEntityIronFurnace.java
+++ b/src/main/java/cazador/furnaceoverhaul/tile/TileEntityIronFurnace.java
@@ -45,8 +45,8 @@ public class TileEntityIronFurnace extends TileEntity implements ITickable {
 	//Constants
 	public static final int SLOT_INPUT = 0;
 	public static final int SLOT_FUEL = 1;
-	public static final int SLOT_OUTPUT = 2;
-	public static final int[] SLOT_UPGRADE = { 3, 4, 5 };
+	public static final int[] SLOT_UPGRADE = { 2, 3, 4 };
+	public static final int SLOT_OUTPUT = 5;
 	public static final int MAX_FE_TRANSFER = 1200;
 	public static final int MAX_ENERGY_STORED = 80000;
 
@@ -60,7 +60,7 @@ public class TileEntityIronFurnace extends TileEntity implements ITickable {
 		public boolean isItemValid(int slot, ItemStack stack) {
 			if (slot == SLOT_INPUT) return SlotFurnaceInput.isStackValid(stack);
 			if (slot == SLOT_FUEL) return SlotFurnaceFuel.isStackValid(stack);
-			return slot > 2 ? SlotUpgrade.isStackValid(stack) : true;
+			return slot < SLOT_OUTPUT ? SlotUpgrade.isStackValid(stack) : true;
 		};
 	};
 	private final RangedWrapper TOP = new RangedWrapper(inv, SLOT_INPUT, SLOT_INPUT + 1);


### PR DESCRIPTION
This prevents XP dupe if players for example TakeHalf and then ShiftClick back in.